### PR TITLE
[FEATURE] Allow script location outside of web root

### DIFF
--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -35,7 +35,12 @@ call_user_func(function($scriptLocation) {
 		require __DIR__ . '/../Scripts/CliDispatch.php';
 		exit(0);
 	} else {
-		define('PATH_thisScript', realpath(PATH_site . 'typo3cms'));
+		if ($scriptLocation) {
+			$scriptPath = $scriptLocation . '/typo3cms';
+		} else {
+			$scriptPath = PATH_site . 'typo3cms';
+		}
+		define('PATH_thisScript', $scriptPath);
 	}
 
 	require PATH_site . 'typo3/sysext/core/Classes/Core/Bootstrap.php';


### PR DESCRIPTION
This allows the typo3cms executable to live outside of the web root,
the TYPO3_PATH_WEB environment variable should be defined in
this case to still have the environment set up properly.