### PR TITLE
[BUGFIX] Inject missing dependency ordering service to be compatible …

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -330,7 +330,14 @@ class ConsoleBootstrap extends Bootstrap {
 		if (is_callable(array($packageManager, 'injectClassLoader'))) {
 			$packageManager->injectClassLoader($this->getEarlyInstance('TYPO3\\CMS\\Core\\Core\\ClassLoader'));
 		}
-		$packageManager->injectDependencyResolver(Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Package\\DependencyResolver'));
+		$dependencyResolver = Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Package\\DependencyResolver');
+		// required since 7.4
+		if (is_callable(array($dependencyResolver, 'injectDependencyOrderingService'))) {
+			$dependencyResolver->injectDependencyOrderingService(
+				Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Service\\DependencyOrderingService')
+			);
+		}
+		$packageManager->injectDependencyResolver($dependencyResolver);
 		$packageManager->initialize($this);
 		Utility\GeneralUtility::setSingletonInstance('TYPO3\\CMS\\Core\\Package\\PackageManager', $packageManager);
 	}


### PR DESCRIPTION
…with master

The dependency ordering has been extracted into its own service and must
be injected into the dependency resolver since 7.4.