### PR TITLE
Call Package boot method only if available

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -63,7 +63,10 @@ class Package extends \TYPO3\CMS\Core\Package\Package {
 	 */
 	public function boot(\TYPO3\Flow\Core\Bootstrap $bootstrap) {
 		if (defined('TYPO3_cliMode') && TYPO3_cliMode && is_callable(array($bootstrap, 'registerRequestHandler'))) {
-			parent::boot($bootstrap);
+			// boot method has been deleted in 7.4
+			if (is_callable('parent::boot')) {
+				parent::boot($bootstrap);
+			}
 			$bootstrap->registerRequestHandler(new RequestHandler($bootstrap));
 			$this->registerCommands($bootstrap);
 		}

--- a/Classes/Package/UncachedPackageManager.php
+++ b/Classes/Package/UncachedPackageManager.php
@@ -49,7 +49,9 @@ class UncachedPackageManager extends PackageManager {
 
 		foreach ($this->activePackages as $package) {
 			/** @var $package Package */
-			$package->boot($bootstrap);
+			if (is_callable(array($package, 'boot'))) {
+				$package->boot($bootstrap);
+			}
 		}
 	}
 


### PR DESCRIPTION
The boot() method of Packages have been removed in 7.4 and should
only be called if they exist to be backwards compatible.