### PR TITLE
[BUGFIX] Fix typo3 autoload.php inclusion

### DIFF
--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -22,7 +22,7 @@ call_user_func(function($scriptLocation) {
 	define('PATH_thisScript', realpath(PATH_site . 'typo3cms'));
 
 	if (@file_exists(PATH_site . 'typo3/sysext/core/Classes/Core/ApplicationInterface.php')) {
-		$classLoader = require_once PATH_site . 'typo3/vendor/autoload.php';
+		$classLoader = require_once PATH_site . 'typo3/../vendor/autoload.php';
 	} else {
 		require_once PATH_site . 'typo3/sysext/core/Classes/Core/Bootstrap.php';
 		require_once PATH_site . 'typo3/sysext/core/Classes/Core/ApplicationContext.php';


### PR DESCRIPTION
The `vendor` directory within `typo3/cms` has been moved one level up to avoid exposure in the web root, thus incorporate this.