### PR TITLE
[BUGFIX] Fix compatibility with PHP < 5.5

### DIFF
--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -131,12 +131,12 @@ class Scripts {
 		} else {
 			$cacheManager = new \TYPO3\CMS\Core\Cache\CacheManager();
 			$cacheManager->setCacheConfigurations($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']);
-			\TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager);
+			\TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager', $cacheManager);
 
 			$cacheFactory = new \TYPO3\CMS\Core\Cache\CacheFactory('production', $cacheManager);
-			\TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheFactory::class, $cacheFactory);
+			\TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance('TYPO3\\CMS\\Core\\Cache\\CacheFactory', $cacheFactory);
 
-			$bootstrap->setEarlyInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager);
+			$bootstrap->setEarlyInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager', $cacheManager);
 		}
 	}
 


### PR DESCRIPTION
TYPO3 6.2 is still supported, thus continue to use PHP 5.3 syntax.