### PR TITLE
[FEATURE] Add database schema update command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ script:
   - ./typo3cms backend:lock
   - ./typo3cms backend:unlock
   - ./typo3cms cleanup:updatereferenceindex
+  - ./typo3cms database:updateschema "*"

--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -1,0 +1,158 @@
+<?php
+namespace Helhum\Typo3Console\Command;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Mathias Brodala <mbrodala@pagemachine.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use Helhum\Typo3Console\Mvc\Controller\CommandController;
+use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateException;
+use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateResult;
+use Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateType;
+use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
+
+/**
+ * Database command controller
+ */
+class DatabaseCommandController extends CommandController {
+
+	/**
+	 * @var \Helhum\Typo3Console\Service\Database\Schema\SchemaService
+	 * @inject
+	 */
+	protected $schemaService;
+
+	/**
+	 * Mapping of schema update types to human-readable labels
+	 *
+	 * @var array
+	 */
+	protected $schemaUpdateTypeLabels = array(
+		SchemaUpdateType::FIELD_ADD => 'Add fields',
+		SchemaUpdateType::FIELD_CHANGE => 'Change fields',
+		SchemaUpdateType::FIELD_DROP => 'Drop fields',
+		SchemaUpdateType::TABLE_ADD => 'Add tables',
+		SchemaUpdateType::TABLE_CHANGE => 'Change tables',
+		SchemaUpdateType::TABLE_CLEAR => 'Clear tables',
+		SchemaUpdateType::TABLE_DROP => 'Drop tables',
+	);
+
+	/**
+	 * Update database schema
+	 *
+	 * See Helhum\Typo3Console\Service\Database\Schema\SchemaUpdateType for a list of valid schema update types.
+	 *
+	 * The list of schema update types supports wildcards to specify multiple types, e.g.:
+	 *
+	 * "*" (all updates)
+	 * "field.*" (all field updates)
+	 * "*.add,*.change" (all add/change updates)
+	 *
+	 * To avoid shell matching all types with wildcards should be quoted.
+	 *
+	 * @param array $schemaUpdateTypes List of schema update types
+	 */
+	public function updateSchemaCommand(array $schemaUpdateTypes) {
+		try {
+			$schemaUpdateTypes = $this->expandSchemaUpdateTypes($schemaUpdateTypes);
+		} catch (\UnexpectedValueException $e) {
+			$this->outputLine(sprintf('<error>%s</error>', $e->getMessage()));
+			$this->sendAndExit(1);
+		}
+
+		$result = $this->schemaService->updateSchema($schemaUpdateTypes);
+
+		if ($result->hasPerformedUpdates()) {
+			$this->output->outputLine('<info>The following schema updates where performed:</info>');
+			$this->outputSchemaUpdateResult($result);
+		} else {
+			$this->output->outputLine('No schema updates matching the given types where performed');
+		}
+	}
+
+	/**
+	 * Expands wildcards in schema update types, e.g. field.* or *.change
+	 *
+	 * @param array $schemaUpdateTypes List of schema update types
+	 * @return SchemaUpdateType[]
+	 * @throws \UnexpectedValueException If an invalid schema update type was passed
+	 */
+	protected function expandSchemaUpdateTypes(array $schemaUpdateTypes) {
+		$expandedSchemaUpdateTypes = array();
+		$schemaUpdateTypeConstants = array_values(SchemaUpdateType::getConstants());
+
+		// Collect total list of types by expanding wildcards
+		foreach ($schemaUpdateTypes as $schemaUpdateType) {
+			if (strpos($schemaUpdateType, '*') !== FALSE) {
+				$matchPattern = '/' . str_replace('\\*', '.+', preg_quote($schemaUpdateType, '/')) . '/';
+				$matchingSchemaUpdateTypes = preg_grep($matchPattern, $schemaUpdateTypeConstants);
+				$expandedSchemaUpdateTypes = array_merge($expandedSchemaUpdateTypes, $matchingSchemaUpdateTypes);
+			} else {
+				$expandedSchemaUpdateTypes[] = $schemaUpdateType;
+			}
+		}
+
+		// Cast to enumeration objects to ensure valid values
+		foreach ($expandedSchemaUpdateTypes as &$schemaUpdateType) {
+			try {
+				$schemaUpdateType = SchemaUpdateType::cast($schemaUpdateType);
+			} catch (InvalidEnumerationValueException $e) {
+				throw new \UnexpectedValueException(sprintf(
+					'Invalid schema update type "%s", must be one of: "%s"',
+					$schemaUpdateType,
+					implode('", "', $schemaUpdateTypeConstants)
+				), 1439460396);
+			}
+		}
+
+		return $expandedSchemaUpdateTypes;
+	}
+
+	/**
+	 * Renders a table for a schema update result
+	 *
+	 * @param SchemaUpdateResult $result Result of the schema update
+	 * @return void
+	 */
+	protected function outputSchemaUpdateResult(SchemaUpdateResult $result) {
+		$tableRows = array();
+
+		foreach ($result->getPerformedUpdates() as $type => $numberOfUpdates) {
+			$tableRows[] = array($this->schemaUpdateTypeLabels[(string)$type], $numberOfUpdates);
+		}
+
+		$this->output->outputTable($tableRows, array('Type', 'Updates'));
+
+		if ($result->hasErrors()) {
+			foreach ($result->getErrors() as $type => $errors) {
+				$this->output->outputLine(sprintf('<error>Errors during "%s" schema update:</error>', $this->schemaUpdateTypeLabels[(string)$type]));
+
+				foreach ($errors as $error) {
+					$this->output->outputFormatted('<error>' . $error . '</error>', array(), 2);
+				}
+			}
+		}
+	}
+}

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -78,6 +78,7 @@ class Package extends \TYPO3\CMS\Core\Package\Package {
 		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\CleanupCommandController');
 		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\DocumentationCommandController');
 		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\InstallCommandController');
+		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\DatabaseCommandController');
 		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\ConfigurationCommandController');
 		$bootstrap->getCommandManager()->registerCommandController('Helhum\Typo3Console\Command\FrontendCommandController');
 

--- a/Classes/Service/Database/Exception.php
+++ b/Classes/Service/Database/Exception.php
@@ -1,0 +1,35 @@
+<?php
+namespace Helhum\Typo3Console\Service\Database;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Mathias Brodala <mbrodala@pagemachine.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Base class for database exceptions
+ */
+class Exception extends \Helhum\Typo3Console\Service\Exception {
+
+}

--- a/Classes/Service/Database/Schema/SchemaService.php
+++ b/Classes/Service/Database/Schema/SchemaService.php
@@ -1,0 +1,117 @@
+<?php
+namespace Helhum\Typo3Console\Service\Database\Schema;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Mathias Brodala <mbrodala@pagemachine.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+/**
+ * Service for database schema migrations
+ */
+class SchemaService implements SingletonInterface {
+
+	/**
+	 * @var \TYPO3\CMS\Install\Service\SqlSchemaMigrationService
+	 * @inject
+	 */
+	protected $schemaMigrationService;
+
+	/**
+	 * @var \TYPO3\CMS\Install\Service\SqlExpectedSchemaService
+	 * @inject
+	 */
+	protected $expectedSchemaService;
+
+	/**
+	 * Mapping of schema update types to internal statement types
+	 *
+	 * @var array
+	 */
+	protected $schemaUpdateTypesStatementTypesMapping = array(
+		SchemaUpdateType::FIELD_ADD => array('add'),
+		SchemaUpdateType::FIELD_CHANGE => array('change', 'change_currentValue'),
+		SchemaUpdateType::FIELD_DROP => array('drop'),
+		SchemaUpdateType::TABLE_ADD => array('create_table'),
+		SchemaUpdateType::TABLE_CHANGE => array('change_table'),
+		SchemaUpdateType::TABLE_CLEAR => array('clear_table'),
+		SchemaUpdateType::TABLE_DROP => array('drop_table'),
+	);
+
+	/**
+	 * Perform necessary database schema migrations
+	 *
+	 * @param SchemaUpdateType[] $schemaUpdateTypes List of permitted schema update types
+	 * @return SchemaUpdateResult Result of the schema update
+	 */
+	public function updateSchema(array $schemaUpdateTypes) {
+		$expectedSchema = $this->expectedSchemaService->getExpectedDatabaseSchema();
+		$currentSchema = $this->schemaMigrationService->getFieldDefinitions_database();
+
+		$addCreateChange = $this->schemaMigrationService->getDatabaseExtra($expectedSchema, $currentSchema);
+		$dropRename = $this->schemaMigrationService->getDatabaseExtra($currentSchema, $expectedSchema);
+
+		$updateStatements = array();
+		ArrayUtility::mergeRecursiveWithOverrule($updateStatements, $this->schemaMigrationService->getUpdateSuggestions($addCreateChange));
+		ArrayUtility::mergeRecursiveWithOverrule($updateStatements, $this->schemaMigrationService->getUpdateSuggestions($dropRename, 'remove'));
+
+		$updateResult = new SchemaUpdateResult();
+
+		foreach ($schemaUpdateTypes as $schemaUpdateType) {
+			$statementTypes = $this->getStatementTypes($schemaUpdateType);
+
+			foreach ($statementTypes as $statementType) {
+				if (isset($updateStatements[$statementType])) {
+					$statements = $updateStatements[$statementType];
+					$result = $this->schemaMigrationService->performUpdateQueries(
+						$statements,
+						// Generate a map of statements as keys and TRUE as values
+						array_combine(array_keys($statements), array_fill(0, count($statements), TRUE))
+					);
+
+					if ($result === TRUE) {
+						$updateResult->addPerformedUpdates($schemaUpdateType, count($statements));
+					} elseif (is_array($result)) {
+						$updateResult->addErrors($schemaUpdateType, $result);
+					}
+				}
+			}
+		}
+
+		return $updateResult;
+	}
+
+	/**
+	 * Map schema update type to a list of internal statement types
+	 *
+	 * @param SchemaUpdateType $schemaUpdateType Schema update types
+	 * @return array
+	 */
+	protected function getStatementTypes(SchemaUpdateType $schemaUpdateType) {
+		return $this->schemaUpdateTypesStatementTypesMapping[(string)$schemaUpdateType];
+	}
+}

--- a/Classes/Service/Database/Schema/SchemaUpdateResult.php
+++ b/Classes/Service/Database/Schema/SchemaUpdateResult.php
@@ -1,0 +1,98 @@
+<?php
+namespace Helhum\Typo3Console\Service\Database\Schema;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Mathias Brodala <mbrodala@pagemachine.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * Represents a database schema update result
+ */
+class SchemaUpdateResult {
+
+  /**
+   * @var array $performedUpdates
+   */
+  protected $performedUpdates = array();
+
+  /**
+   * Returns the list of performed updates, grouped by schema update type
+   *
+   * @return array
+   */
+  public function getPerformedUpdates() {
+    return $this->performedUpdates;
+  }
+
+  /**
+   * Returns TRUE if updates where performed, FALSE otherwise
+   *
+   * @return boolean
+   */
+  public function hasPerformedUpdates() {
+    return count($this->performedUpdates);
+  }
+
+  /**
+   * Adds to the number of updates performed for a schema update type
+   *
+   * @param SchemaUpdateType $schemaUpdateType Schema update type
+   * @param int $numberOfUpdates Number of updates performed
+   */
+  public function addPerformedUpdates(SchemaUpdateType $schemaUpdateType, $numberOfUpdates) {
+    $this->performedUpdates[(string)$schemaUpdateType] += $numberOfUpdates;
+  }
+
+  /**
+   * @var array $errors
+   */
+  protected $errors = array();
+
+  /**
+   * @return array
+   */
+  public function getErrors() {
+    return $this->errors;
+  }
+
+  /**
+   * Adds to the list of errors occurred for a schema update type
+   *
+   * @param SchemaUpdateType $schemaUpdateType Schema update type
+   * @param array $errors List of error messages
+   */
+  public function addErrors(SchemaUpdateType $schemaUpdateType, array $errors) {
+    $this->errors[(string)$schemaUpdateType] = array_merge((array)$this->errors[(string)$schemaUpdateType], $errors);
+  }
+
+  /**
+   * Returns TRUE if errors did occur during schema update, FALSE otherwise
+   *
+   * @return boolean
+   */
+  public function hasErrors() {
+    return count($this->errors);
+  }
+}

--- a/Classes/Service/Database/Schema/SchemaUpdateType.php
+++ b/Classes/Service/Database/Schema/SchemaUpdateType.php
@@ -1,0 +1,76 @@
+<?php
+namespace Helhum\Typo3Console\Service\Database\Schema;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2015 Mathias Brodala <mbrodala@pagemachine.de>
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the text file GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Type\Enumeration;
+
+/**
+ * List of database schema update types
+ */
+class SchemaUpdateType extends Enumeration {
+
+	/**
+	 * @var int
+	 */
+	protected $value;
+
+	/**
+	 * Add a field
+	 */
+	const FIELD_ADD = 'field.add';
+
+	/**
+	 * Change a field
+	 */
+	const FIELD_CHANGE = 'field.change';
+
+	/**
+	 * Drop a field
+	 */
+	const FIELD_DROP = 'field.drop';
+
+	/**
+	 * Add a table
+	 */
+	const TABLE_ADD = 'table.add';
+
+	/**
+	 * Change a table
+	 */
+	const TABLE_CHANGE = 'table.change';
+
+	/**
+	 * Drop a table
+	 */
+	const TABLE_DROP = 'table.drop';
+
+	/**
+	 * Truncate a table
+	 */
+	const TABLE_CLEAR = 'table.clear';
+}

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -62,6 +62,9 @@ Additionally it provides some commands, that wouldn't be possible at all with th
 	# Populate essential core caches
 	./typo3cms cache:warmup
 
+	# Perform safe database schema updates
+	./typo3cms database:updateschema "*.add,*.change"
+
 A help system is integrated, so that you can easily list all available commands or get help for individual commands:
 
 .. code-block:: bash


### PR DESCRIPTION
This adds a "database:updateschema" command which performs database schema
updates. The types of schema updates to be performed need to be specified
explicitely to avoid accidently dropping fields/tables.

Wildcards can be used to specify multiple schema update types easily, e.g.:

./typo3cms database:updateschema "*.add,*.change"

To avoid shell matching all types with wildcards should be quoted.

Fixes #13