### PR TITLE
[FEATURE] Make it possible so move typo3cms outside of web folder

### DIFF
--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -19,7 +19,7 @@ call_user_func(function($scriptLocation) {
 	}
 
 	define('PATH_site', strtr($webRoot, '\\', '/') . '/');
-	define('PATH_thisScript', realpath(PATH_site . 'typo3cms'));
+	define('PATH_thisScript', realpath(($scriptLocation ?: $webRoot) . '/typo3cms'));
 
 	if (@file_exists(PATH_site . 'typo3/sysext/core/Classes/Core/ApplicationInterface.php')) {
 		foreach (array(PATH_site . 'typo3/../vendor/autoload.php', PATH_site . 'typo3/vendor/autoload.php') as $possibleAutoloadLocation) {


### PR DESCRIPTION
Create a typo3cms file just outside of you webroot with this content:

```
#!/usr/bin/env php
<?php

/**
* Bootstrap for the command line
*/
$__self_dir = __DIR__;
putenv('TYPO3_PATH_WEB='. __DIR__ . '/web');
require __DIR__ . '/web/typo3conf/ext/typo3_console/Scripts/typo3cms.php';
```