### PR TITLE
[TASK] Update TYPO3 Version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "license": "GPL-2.0+",
     "require": {
         "ext-Phar": "*",
-        "typo3/cms-core": "^7.6",
+        "typo3/cms-core": "^8.9",
         "symfony/console": "^2.7",
         "symfony/process": "^2.7"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -27,7 +27,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'typo3' => '7.4.0-7.99.99',
+      'typo3' => '7.4.0-8.0.99',
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
In order to allow install in master change the version requirements to allow installation under 8.0.x versions of TYPO3.