### PR TITLE
[BUGFIX] Allow build failures against TYPO3 master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
     - TYPO3_VERSION=^7.6
     - TYPO3_VERSION=dev-master
 
+matrix:
+  allow_failures:
+    - env: TYPO3_VERSION=dev-master
+
 sudo: false
 
 addons:


### PR DESCRIPTION
Errors while building against TYPO3 master should not prevent releases.