### PR TITLE
[TASK] Allow further paths for typo3cms

### DIFF
--- a/Scripts/typo3cms
+++ b/Scripts/typo3cms
@@ -30,6 +30,7 @@ call_user_func(function() {
 		getcwd(),
 		__DIR__ . '/Web',
 		__DIR__ . '/web',
+		__DIR__ . '/../web'
 	);
 
 	$path = getcwd();


### PR DESCRIPTION
There are setups in which typo3cms script should
reside outside the public WEB_ROOT. Allow e.g.

bin/typo3cms
Shell/typo3cms

as locations for
web/typo3conf/ext/typo3_console/Scripts/typo3cms

Directory __DIR__ . '/../Web' is not added since composer
based setups create lower-case web folder.

Signed-off-by: Felix Kopp <felix-source@phorax.com>

Resolves: #108 