### PR TITLE
Path to composer files to be configurable

### DIFF
--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -76,8 +76,9 @@ class InstallCommandController extends CommandController
     }
 
     /**
-     * Activates all packages that are configured in composer.json or are required. If no composerFilePath is
-     * given, the Typo3 root path (PATH_site) will be used for file lookup.
+     * Activates all packages that are configured in composer.json or are required.
+     *
+     * If no composerFilePath is given, the Typo3 root path (PATH_site) will be used for file lookup.
      *
      * @param bool $removeInactivePackages
      * @param string $composerFilesPath Path to composer files (will use PATH_site by default)


### PR DESCRIPTION
This extension is awesome, totally what we needed for our current project! Thanks so much.

However our Typo3 setup is a bit different, as the composer files are not within PATH_site, but in the parent directory. So I tweaked your extension a little, in order to make the path configurable

`./typo3cms install:generatepackagestates --composer-files-path=/path/to/composer/files`

If not specified, PATH_site will still be used.

Would be cool if you could merge it! Please let me know if you want to have something changed.