### PR TITLE
[TASK] Remove cache_classes from watched core cache configurations

### DIFF
--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -78,7 +78,6 @@ class Scripts
         foreach (
             array(
                 'cache_core',
-                'cache_classes',
                 'dbal',
             ) as $id) {
             if (isset($cacheConfigurations[$id])) {


### PR DESCRIPTION
With class loader removal in [#67212](https://forge.typo3.org/issues/67212) cache_classes was removed from
the system.
This patch removes the leftover of cache_classes.

See also: https://forge.typo3.org/issues/67411