### PR TITLE
Port for 1.1.x branch: [BUGFIX] Fix cache configuration in run level full

### DIFF
--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -65,7 +65,7 @@ class RunLevel {
 	 * @internal
 	 */
 	public function addBootingStepForCommand($commandIdentifier, $stepIdentifier) {
-		if (!isset($this->commandOptions[$commandIdentifier]['addSteps'])) {
+		if (!isset($this->commandOptions[$commandIdentifier]['addSteps'][$stepIdentifier])) {
 			$this->commandOptions[$commandIdentifier]['addSteps'][$stepIdentifier] = $stepIdentifier;
 		}
 
@@ -205,10 +205,10 @@ class RunLevel {
 		$sequence = $parentSequence ?: $this->buildBasicRuntimeSequence($identifier);
 
 		$this->addStep($sequence, 'helhum.typo3console:database', !empty($this->executedSequences[self::LEVEL_FULL]));
-		$this->addStep($sequence, 'helhum.typo3console:persistence', !empty($this->executedSequences[self::LEVEL_FULL]));
-		$this->addStep($sequence, 'helhum.typo3console:authentication', !empty($this->executedSequences[self::LEVEL_FULL]));
 		// Fix core caches that were disabled beforehand
 		$this->addStep($sequence, 'helhum.typo3console:enablecorecaches');
+		$this->addStep($sequence, 'helhum.typo3console:persistence', !empty($this->executedSequences[self::LEVEL_FULL]));
+		$this->addStep($sequence, 'helhum.typo3console:authentication', !empty($this->executedSequences[self::LEVEL_FULL]));
 
 		$this->executedSequences[self::LEVEL_FULL] = TRUE;
 		return $sequence;
@@ -264,7 +264,7 @@ class RunLevel {
 				break;
 			case 'helhum.typo3console:enablecorecaches':
 				$action = $isDummyStep ? function(){} : array('Helhum\Typo3Console\Core\Booting\Scripts', 'reEnableOriginalCoreCaches');
-				$sequence->addStep(new Step('helhum.typo3console:enablecorecaches', $action), 'helhum.typo3console:authentication');
+				$sequence->addStep(new Step('helhum.typo3console:enablecorecaches', $action), 'helhum.typo3console:database');
 				break;
 
 			// Part of full runtime

--- a/Classes/Core/Booting/RunLevel.php
+++ b/Classes/Core/Booting/RunLevel.php
@@ -188,9 +188,6 @@ class RunLevel {
 		if (empty($this->executedSequences[self::LEVEL_COMPILE])) {
 			// Only execute if not already executed in compile time
 			$sequence->addStep(new Step('helhum.typo3console:providecleanclassimplementations', array('Helhum\Typo3Console\Core\Booting\Scripts', 'provideCleanClassImplementations')), 'helhum.typo3console:extensionconfiguration');
-		} else {
-			// Fix core caches that were disabled in compile time
-			$this->addStep($sequence, 'helhum.typo3console:enablecorecaches');
 		}
 
 		$this->executedSequences[self::LEVEL_MINIMAL] = TRUE;
@@ -210,6 +207,8 @@ class RunLevel {
 		$this->addStep($sequence, 'helhum.typo3console:database', !empty($this->executedSequences[self::LEVEL_FULL]));
 		$this->addStep($sequence, 'helhum.typo3console:persistence', !empty($this->executedSequences[self::LEVEL_FULL]));
 		$this->addStep($sequence, 'helhum.typo3console:authentication', !empty($this->executedSequences[self::LEVEL_FULL]));
+		// Fix core caches that were disabled beforehand
+		$this->addStep($sequence, 'helhum.typo3console:enablecorecaches');
 
 		$this->executedSequences[self::LEVEL_FULL] = TRUE;
 		return $sequence;
@@ -265,7 +264,7 @@ class RunLevel {
 				break;
 			case 'helhum.typo3console:enablecorecaches':
 				$action = $isDummyStep ? function(){} : array('Helhum\Typo3Console\Core\Booting\Scripts', 'reEnableOriginalCoreCaches');
-				$sequence->addStep(new Step('helhum.typo3console:enablecorecaches', $action), 'helhum.typo3console:coreconfiguration');
+				$sequence->addStep(new Step('helhum.typo3console:enablecorecaches', $action), 'helhum.typo3console:authentication');
 				break;
 
 			// Part of full runtime

--- a/Classes/Core/Booting/Scripts.php
+++ b/Classes/Core/Booting/Scripts.php
@@ -47,7 +47,6 @@ class Scripts {
 	 */
 	static public function initializeConfigurationManagement(ConsoleBootstrap $bootstrap) {
 		$bootstrap->initializeConfigurationManagement();
-		self::$earlyCachesConfiguration = $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'];
 		self::disableCachesForObjectManagement();
 	}
 
@@ -95,6 +94,17 @@ class Scripts {
 	 * @param ConsoleBootstrap $bootstrap
 	 */
 	static public function disableCoreCaches(ConsoleBootstrap $bootstrap) {
+		$cacheConfigurations = &$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'];
+		foreach (
+			array(
+				'cache_core',
+				'cache_classes',
+				'dbal',
+			) as $id) {
+			if (isset($cacheConfigurations[$id])) {
+				self::$earlyCachesConfiguration[$id] = $cacheConfigurations[$id];
+			}
+		}
 		$bootstrap->disableCoreCaches();
 	}
 
@@ -105,7 +115,7 @@ class Scripts {
 	 * @param ConsoleBootstrap $bootstrap
 	 */
 	static public function reEnableOriginalCoreCaches(ConsoleBootstrap $bootstrap) {
-		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] = self::$earlyCachesConfiguration;
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'] = array_replace_recursive($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'], self::$earlyCachesConfiguration);
 
 		/** @var CacheManager $cacheManager */
 		$cacheManager = $bootstrap->getEarlyInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager');

--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -353,6 +353,7 @@ class ConsoleBootstrap extends Bootstrap {
 		/** @var PackageManager $packageManager */
 		$packageManager = $this->getEarlyInstance($this->packageManagerInstanceName);
 		if ($packageManager->isPackageActive('dbal')) {
+			$cacheConfigurations = &$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'];
 			$cacheConfigurations['dbal'] = array(
 				'backend' => 'TYPO3\\CMS\\Core\\Cache\\Backend\\TransientMemoryBackend',
 				'groups' => array()

--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -84,6 +84,7 @@ class Package extends \TYPO3\CMS\Core\Package\Package {
 
 		$bootstrap->setRunLevelForCommand('typo3_console:install:databasedata', RunLevel::LEVEL_MINIMAL);
 		$bootstrap->addBootingStepForCommand('typo3_console:install:databasedata', 'helhum.typo3console:database');
+		$bootstrap->addBootingStepForCommand('typo3_console:install:databasedata', 'helhum.typo3console:enablecorecaches');
 		$bootstrap->setRunLevelForCommand('typo3_console:install:defaultconfiguration', RunLevel::LEVEL_FULL);
 		$bootstrap->setRunLevelForCommand('typo3_console:install:*', RunLevel::LEVEL_COMPILE);
 


### PR DESCRIPTION
This is a port for the 6.2 related branch 1.1.x.

Original commit is: https://github.com/helhum/typo3_console/commit/80146788e578addb427190d3d83f22512f062f95

Fixes #119
Fixes #57