### PR TITLE
[BUGFIX] Use install utility signal to copy script

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,11 +4,12 @@ defined('TYPO3_MODE') or die('Access denied.');
 call_user_func(function ($extensionKey) {
     if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI)) {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter(\Helhum\Typo3Console\Property\TypeConverter\ArrayConverter::class);
-    } elseif (TYPO3_MODE === 'BE' && isset($_GET['M']) && 'tools_ExtensionmanagerExtensionmanager' === $_GET['M']) {
+    }
+    if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_CLI) || (TYPO3_MODE === 'BE' && isset($_GET['M']) && 'tools_ExtensionmanagerExtensionmanager' === $_GET['M'])) {
         $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
         $signalSlotDispatcher->connect(
-            \TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService::class,
-            'hasInstalledExtensions',
+            \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,
+            'afterExtensionInstall',
             \Helhum\Typo3Console\Hook\ExtensionInstallation::class,
             'afterInstallation'
         );


### PR DESCRIPTION
The install extension command does only use the install utility,
thus we need to listen to that signal to copy our script.