### PR TITLE
[FEATURE] Auto activate console if possible

### DIFF
--- a/Classes/Core/ConsoleBootstrap.php
+++ b/Classes/Core/ConsoleBootstrap.php
@@ -89,12 +89,13 @@ class ConsoleBootstrap extends Bootstrap
             $this->defineTypo3RequestTypes();
         }
         $this->requestId = uniqid();
+        $this->initializePackageManagement();
+
         $this->runLevel = new RunLevel();
         $this->setEarlyInstance(\Helhum\Typo3Console\Core\Booting\RunLevel::class, $this->runLevel);
         new ExceptionHandler();
 
         $this->initializeCommandManager();
-        $this->initializePackageManagement();
         $this->registerRequestHandler(new RequestHandler($this));
 
         $requestHandler = $this->resolveCliRequestHandler();
@@ -236,12 +237,6 @@ class ConsoleBootstrap extends Bootstrap
         define('TYPO3_cliMode', true);
         $GLOBALS['MCONF']['name'] = '_CLI_lowlevel';
         parent::baseSetup($pathPart);
-        if (!self::usesComposerClassLoading() && $this->applicationContext->isTesting()) {
-            echo 'TYPO3 Console does not work in application context Testing!' . PHP_EOL
-                . 'This is a reserved context for testing the TYPO3 core.' . PHP_EOL
-                . 'Please use subcontexts Development/Testing or Production/Testing instead.' . PHP_EOL;
-            exit(1);
-        }
         // I want to see deprecation messages
         error_reporting(E_ALL & ~(E_STRICT | E_NOTICE));
     }
@@ -266,7 +261,6 @@ class ConsoleBootstrap extends Bootstrap
     public function initializePackageManagement($packageManagerClassName = \Helhum\Typo3Console\Package\UncachedPackageManager::class)
     {
         require __DIR__ . '/../Package/UncachedPackageManager.php';
-
         $packageManager = new \Helhum\Typo3Console\Package\UncachedPackageManager();
         $this->setEarlyInstance(\TYPO3\CMS\Core\Package\PackageManager::class, $packageManager);
         Utility\ExtensionManagementUtility::setPackageManager($packageManager);

--- a/Documentation/AdministratorManual/Index.rst
+++ b/Documentation/AdministratorManual/Index.rst
@@ -41,9 +41,7 @@ The extension will automatically be activated and the ``typo3cms`` script will a
 .. code-block:: bash
 
 	git clone https://github.com/helhum/typo3_console.git typo3conf/ext/typo3_console
-
-Don't forget to **activate the extension** in the extension manager. Once you active the extension
-the ``typo3cms`` script is automatically copied to your TYPO3 root directory.
+	ln -s typo3conf/ext/typo3_console/Scripts/typo3cms typo3cms
 
 3. Via composer
 ^^^^^^^^^^^^^^^
@@ -63,10 +61,6 @@ Create a root ``composer.json`` file like this add the missing lines to your exi
 		}
 	}
 
-Don't forget to **activate the extension** in the extension manager or directly on the shell ::
 
-	typo3/cli_dispatch.phpsh extbase extension:install typo3_console
-
-
-The ``typo3cms`` script will automatically be copied to your TYPO3 root directory.
+The ``typo3cms`` script will automatically be linked to your TYPO3 root directory and the extension will activate itself automatically as well.
 

--- a/README.md
+++ b/README.md
@@ -41,16 +41,18 @@ just type:
 
 ## Installation
 
-For the extension to work, it *must* be installed in the typo3conf/ext/ directory *not* in any other possible extension location.
+For the extension to work, it **must** be installed in the typo3conf/ext/ directory **not** in any other possible extension location.
+This directory **must not** be a symlink to another location!
 
-Don't forget to activate the extension in the extension manager, which will copy the `typo3cms` command line tool
-into the installation root directory..
+If you activate the extension in the extension manager, it will copy the `typo3cms` command line tool
+into the installation root directory. But it is also possible to create a symlink to `typo3conf/ext/typo3_console/Scripts/typo3cms`
+in any place you want. The console will activate itself on first usage.
 
 ### Linux and OS X Shell Installation
 
 ```
 git clone https://github.com/helhum/typo3_console.git typo3conf/ext/typo3_console
-php typo3/cli_dispatch.phpsh extbase extension:install typo3_console
+ln -s typo3conf/ext/typo3_console/Scripts/typo3cms typo3cms
 php typo3cms help
 ```
 


### PR DESCRIPTION
Remove the need to activate the extension at all.
Now only linking (or copy) to the desired directory
is needed.