### PR TITLE
[FEATURE] Add database import/export commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,8 @@ script:
   - ./typo3cms cache:listgroups
   - ./typo3cms cleanup:updatereferenceindex
   - ./typo3cms database:updateschema "*"
+  - ./typo3cms database:export > /dev/null
+  - echo "SELECT username from be_users where admin=1;" | ./typo3cms database:import
   - ./typo3cms frontend:request / > /dev/null
   - ./typo3cms documentation:generatexsd TYPO3\\CMS\\Fluid\\ViewHelpers > /dev/null
   - ./typo3cms configuration:show BE/installToolPassword

--- a/Classes/ImportExport/Database/Configuration/ConnectionConfiguration.php
+++ b/Classes/ImportExport/Database/Configuration/ConnectionConfiguration.php
@@ -1,0 +1,48 @@
+<?php
+namespace Helhum\Typo3Console\ImportExport\Database\Configuration;
+
+/**
+ * This file is part of the typo3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ */
+
+/**
+ * Class ConnectionConfiguration
+ */
+class ConnectionConfiguration
+{
+    /**
+     * Returns a normalized DB configuration array
+     *
+     * @return array
+     */
+    public function build()
+    {
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']) && is_array($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'])) {
+            // We are on TYPO3 > 8.0
+            $dbConfig = $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default'];
+        } else {
+            // @deprecated with 8 will be removed when 7 Support is dropped
+            $dbConfig = array(
+                'dbname' => TYPO3_db,
+                'host' => TYPO3_db_host,
+                'user' => TYPO3_db_username,
+                'password' => TYPO3_db_password,
+            );
+            if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['port'])) {
+                $dbConfig['port'] = $GLOBALS['TYPO3_CONF_VARS']['DB']['port'];
+            }
+            if (isset($GLOBALS['TYPO3_CONF_VARS']['DB']['socket'])) {
+                $dbConfig['unix_socket'] = $GLOBALS['TYPO3_CONF_VARS']['DB']['socket'];
+            }
+        }
+        return $dbConfig;
+    }
+}

--- a/Classes/ImportExport/Database/Process/MysqlCommand.php
+++ b/Classes/ImportExport/Database/Process/MysqlCommand.php
@@ -1,0 +1,114 @@
+<?php
+namespace Helhum\Typo3Console\ImportExport\Database\Process;
+
+/**
+ * This file is part of the typo3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ */
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+/**
+ * Class MysqlCommand
+ */
+class MysqlCommand
+{
+    /**
+     * @var ProcessBuilder
+     */
+    protected $processBuilder;
+
+    /**
+     * @var array
+     */
+    protected $dbConfig = array();
+
+    /**
+     * MysqlCommand constructor.
+     *
+     * @param array $dbConfig
+     * @param ProcessBuilder $processBuilder
+     */
+    public function __construct(array $dbConfig, ProcessBuilder $processBuilder)
+    {
+        $this->dbConfig = $dbConfig;
+        $this->processBuilder = $processBuilder;
+    }
+
+    /**
+     * @param array $additionalArguments
+     * @param resource $inputStream
+     * @param null $outputCallback
+     * @return int
+     */
+    public function mysql(array $additionalArguments = array(), $inputStream = STDIN, $outputCallback = null)
+    {
+        $this->processBuilder->setPrefix('mysql');
+        $this->processBuilder->setArguments(array_merge($this->buildConnectionArguments(), $additionalArguments));
+        $process = $this->processBuilder->getProcess();
+        $process->setInput($inputStream);
+        return $process->run($this->buildDefaultOutputCallback($outputCallback));
+    }
+
+    /**
+     * @param array $additionalArguments
+     * @param null $outputCallback
+     * @return int
+     */
+    public function mysqldump(array $additionalArguments = array(), $outputCallback = null)
+    {
+        $this->processBuilder->setPrefix('mysqldump');
+        $this->processBuilder->setArguments(array_merge($this->buildConnectionArguments(), $additionalArguments));
+        $process = $this->processBuilder->getProcess();
+        return $process->run($this->buildDefaultOutputCallback($outputCallback));
+    }
+
+    /**
+     * @param callable $outputCallback
+     * @return callable
+     */
+    protected function buildDefaultOutputCallback($outputCallback)
+    {
+        if (!is_callable($outputCallback)) {
+            $outputCallback = function ($type, $output) {
+                if (Process::OUT === $type) {
+                    // Explicitly just echo out for now (avoid symfony console formatting)
+                    echo $output;
+                }
+            };
+        }
+        return $outputCallback;
+    }
+
+    protected function buildConnectionArguments()
+    {
+        if (!empty($this->dbConfig['user'])) {
+            $arguments[] = '-u';
+            $arguments[] = $this->dbConfig['user'];
+        }
+        if (!empty($this->dbConfig['password'])) {
+            $arguments[] = '-p' . $this->dbConfig['password'];
+        }
+        if (!empty($this->dbConfig['host'])) {
+            $arguments[] = '-h';
+            $arguments[] = $this->dbConfig['host'];
+        }
+        if (!empty($this->dbConfig['port'])) {
+            $arguments[] = '-P';
+            $arguments[] = $this->dbConfig['port'];
+        }
+        if (!empty($this->dbConfig['unix_socket'])) {
+            $arguments[] = '-S';
+            $arguments[] = $this->dbConfig['unix_socket'];
+        }
+        $arguments[] = $this->dbConfig['dbname'];
+        return $arguments;
+    }
+}

--- a/Classes/Install/PackageStatesGenerator.php
+++ b/Classes/Install/PackageStatesGenerator.php
@@ -14,7 +14,6 @@ namespace Helhum\Typo3Console\Install;
  */
 
 use Helhum\Typo3Console\Package\UncachedPackageManager;
-use TYPO3\CMS\Core\Package\Package;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 /**
@@ -33,9 +32,9 @@ class PackageStatesGenerator
         foreach ($packageManager->getAvailablePackages() as $package) {
             if (
                 isset($frameworkExtensionsFromConfiguration[$package->getPackageKey()])
-                || ($activateDefaultExtensions && $package->isPartOfFactoryDefault())
                 || $package->isProtected()
-                || ($package instanceof Package && $package->isPartOfMinimalUsableSystem())
+                || $package->isPartOfMinimalUsableSystem()
+                || ($activateDefaultExtensions && $package->isPartOfFactoryDefault())
                 // Every extension available in typo3conf/ext is meant to be active
                 || strpos(PathUtility::stripPathSitePrefix($package->getPackagePath()), 'typo3conf/ext/') !== false
             ) {

--- a/Configuration/Console/Commands.php
+++ b/Configuration/Console/Commands.php
@@ -10,6 +10,8 @@ return array(
         \Helhum\Typo3Console\Command\DatabaseCommandController::class,
         \Helhum\Typo3Console\Command\ConfigurationCommandController::class,
         \Helhum\Typo3Console\Command\FrontendCommandController::class,
+        \Helhum\Typo3Console\Command\ExportCommandController::class,
+        \Helhum\Typo3Console\Command\ImportCommandController::class,
     ),
     'runLevels' => array(
         'typo3_console:install:databasedata' => \Helhum\Typo3Console\Core\Booting\RunLevel::LEVEL_MINIMAL ,


### PR DESCRIPTION
This adds the feature like requested in #93 and suggested in #95
but with the conceptual change, that imports and exports are done
over stdin and stdout instead of using files.

This adds much more flexibility and is secure by default, as the output
is never stored in a file, which could be compromised.

This is also a small step to get #125 resolved.