### PR TITLE
[FEATURE] Add mysql interactive mode for database:import

### DIFF
--- a/Classes/Command/DatabaseCommandController.php
+++ b/Classes/Command/DatabaseCommandController.php
@@ -82,8 +82,11 @@ class DatabaseCommandController extends CommandController
      * This means that this can not only be used to pass insert statements,
      * it but works as well to pass SELECT statements to it.
      * The mysql binary must be available in the path for this command to work.
+     *
+     * @param bool $interactive
+     * @throws \TYPO3\CMS\Extbase\Mvc\Exception\StopActionException
      */
-    public function importCommand()
+    public function importCommand($interactive = false)
     {
         $mysqlCommand = new MysqlCommand(
             $this->connectionConfiguration->build(),
@@ -99,7 +102,8 @@ class DatabaseCommandController extends CommandController
                 } else {
                     $this->output('<error>' . $output . '</error>');
                 }
-            }
+            },
+            $interactive
         );
         $this->quit($exitCode);
     }

--- a/Classes/Database/Process/MysqlCommand.php
+++ b/Classes/Database/Process/MysqlCommand.php
@@ -13,6 +13,7 @@ namespace Helhum\Typo3Console\Database\Process;
  *
  */
 
+use Helhum\Typo3Console\Mvc\Cli\InteractiveProcess;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
 
@@ -47,15 +48,22 @@ class MysqlCommand
      * @param array $additionalArguments
      * @param resource $inputStream
      * @param null $outputCallback
+     * @param bool $interactive
      * @return int
      */
-    public function mysql(array $additionalArguments = array(), $inputStream = STDIN, $outputCallback = null)
+    public function mysql(array $additionalArguments = array(), $inputStream = STDIN, $outputCallback = null, $interactive = false)
     {
         $this->processBuilder->setPrefix('mysql');
         $this->processBuilder->setArguments(array_merge($this->buildConnectionArguments(), $additionalArguments));
-        $process = $this->processBuilder->getProcess();
-        $process->setInput($inputStream);
-        return $process->run($this->buildDefaultOutputCallback($outputCallback));
+        if ($interactive) {
+            // I did not figure out how to change pipes with symfony/process
+            $interactiveProcess = new InteractiveProcess();
+            return $interactiveProcess->run($this->processBuilder->getProcess()->getCommandLine());
+        } else {
+            $process = $this->processBuilder->getProcess();
+            $process->setInput($inputStream);
+            return $process->run($this->buildDefaultOutputCallback($outputCallback));
+        }
     }
 
     /**

--- a/Classes/Mvc/Cli/CommandDispatcher.php
+++ b/Classes/Mvc/Cli/CommandDispatcher.php
@@ -14,7 +14,7 @@ namespace Helhum\Typo3Console\Mvc\Cli;
  */
 
 /**
- * Class Disptacher
+ * Class CommandDispatcher
  */
 class CommandDispatcher
 {

--- a/Classes/Mvc/Cli/InteractiveProcess.php
+++ b/Classes/Mvc/Cli/InteractiveProcess.php
@@ -1,0 +1,38 @@
+<?php
+namespace Helhum\Typo3Console\Mvc\Cli;
+
+/*
+ * This file is part of the TYPO3 console project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read
+ * LICENSE file that was distributed with this source code.
+ *
+ */
+
+/**
+ * Class InteractiveProcess
+ */
+class InteractiveProcess
+{
+    public function run($command)
+    {
+        $returnValue = 1;
+        $pipes = array( );
+        $descriptors = array(
+            array('file', 'php://stdin', 'r'),   // stdin is a file that the child will read from
+            array('file', 'php://stdout', 'w'),  // stdout is a file that the child will write to
+            array('pipe', 'w')                   // stderr is a file that the child will write to
+        );
+
+        $process = @proc_open($command, $descriptors, $pipes);
+
+        if (is_resource($process)) {
+            $returnValue = proc_close($process);
+        }
+        return $returnValue;
+    }
+}


### PR DESCRIPTION
`database:import --interactive` now opens a mysql console
with the DB connection details taken from the TYPO3 configuration