### PR TITLE
[BUGFIX] Do not use back paths for PATH_site in non composer mode

### DIFF
--- a/Scripts/typo3cms.php
+++ b/Scripts/typo3cms.php
@@ -20,7 +20,7 @@ call_user_func(function () {
         $typo3Root = getenv('TYPO3_PATH_WEB');
     } else {
         // Not symlinked (hopefully), so we can assume the docroot from the location of this file
-        $typo3Root = __DIR__ . '/../../../..';
+        $typo3Root = dirname(dirname(dirname(dirname(__DIR__))));
     }
 
     $classLoader = require_once realpath($typo3Root . '/typo3') . '/../vendor/autoload.php';


### PR DESCRIPTION
When in non composer mode, we must not use ../ for use in
the PATH_site constant, as it has several side effects.

Fixes: #177