### PR TITLE
[BUGFIX] Add --site-setup-type option for non interactive install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ script:
 
   # Basic functional tests - all commands should exit with 0
   - ./typo3cms help && [ ! -f "$TYPO3_PATH_WEB/typo3conf/PackageStates.php" ]
-  - ./typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install"
+  - ./typo3cms install:setup --non-interactive --database-user-name="root" --database-host-name="localhost" --database-port="3306" --database-name="travis_test" --admin-user-name="admin" --admin-password="password" --site-name="Travis Install" --site-setup-type="createsite"
+  - echo 'select uid,title from pages limit 1' | ./typo3cms database:import | sed 's/[[:blank:]]//g' | grep 1Home
   - ./typo3cms help
   - ./typo3cms backend:lock
   - ./typo3cms backend:unlock

--- a/Classes/Command/InstallCommandController.php
+++ b/Classes/Command/InstallCommandController.php
@@ -54,9 +54,22 @@ class InstallCommandController extends CommandController
      * @param string $adminUserName
      * @param string $adminPassword
      * @param string $siteName
+     * @param string $siteSetupType
      */
-    public function setupCommand($nonInteractive = false, $databaseUserName = '', $databaseUserPassword = '', $databaseHostName = '', $databasePort = '', $databaseSocket = '', $databaseName = '', $databaseCreate = '', $adminUserName = '', $adminPassword = '', $siteName = 'New TYPO3 Console site')
-    {
+    public function setupCommand(
+        $nonInteractive = false,
+        $databaseUserName = '',
+        $databaseUserPassword = '',
+        $databaseHostName = '',
+        $databasePort = '',
+        $databaseSocket = '',
+        $databaseName = '',
+        $databaseCreate = '',
+        $adminUserName = '',
+        $adminPassword = '',
+        $siteName = 'New TYPO3 Console site',
+        $siteSetupType = 'none'
+    ) {
         $this->outputLine();
         $this->outputLine('<options=bold>Welcome to the console installer of TYPO3 CMS!</options=bold>');
 
@@ -211,10 +224,10 @@ class InstallCommandController extends CommandController
     /**
      * Write default configuration
      *
-     * @param string $siteSetupType Specify the setup type: Download the list of distributions (loaddistribution), Create empty root page (createsite), Do nothing (donothing)
+     * @param string $siteSetupType Specify the setup type: Download the list of distributions (loaddistribution), Create empty root page (createsite), Do nothing (none)
      * @internal
      */
-    public function defaultConfigurationCommand($siteSetupType = 'createsite')
+    public function defaultConfigurationCommand($siteSetupType = 'none')
     {
         $this->cliSetupRequestHandler->executeActionWithArguments('defaultConfiguration', array('sitesetup' => $siteSetupType));
     }


### PR DESCRIPTION
At the same time, use the same default as in previous versions
of typo3_console, which was do nothing.

Fixes #179