### PR TITLE
[TASK] Streamline and document backend restrictions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,8 @@ script:
   - ./typo3cms help
   - ./typo3cms backend:lock
   - ./typo3cms backend:unlock
+  - ./typo3cms backend:lockforeditors
+  - ./typo3cms backend:unlockforeditors
   - ./typo3cms cache:flush
   - ./typo3cms cache:listgroups
   - ./typo3cms cleanup:updatereferenceindex

--- a/Classes/Service/Configuration/ConfigurationService.php
+++ b/Classes/Service/Configuration/ConfigurationService.php
@@ -149,6 +149,9 @@ class ConfigurationService implements SingletonInterface
     }
 
     /**
+     * Returns true if the value is stored in the LocalConfiguration.php file and
+     * is NOT overridden later (e.g. in AdditionalConfiguration.php)
+     *
      * @param string $path
      * @return bool
      */


### PR DESCRIPTION
The backend restriction commands are now streamlined to be more understandable.
Besides that, a documentation is added on top of the class.

Goal is to document every command controller class like that prior to 3.0 release.

This is a breaking change only for early adopters of the 3.0.x-dev branch,
as the editor lock commands were not available brforehand.