### PR TITLE
[BUGFIX] Output process error output to stderr

### DIFF
--- a/Classes/Command/DocumentationCommandController.php
+++ b/Classes/Command/DocumentationCommandController.php
@@ -65,7 +65,8 @@ class DocumentationCommandController extends CommandController implements Single
             $this->sendAndExit(1);
         }
         if ($targetFile === null) {
-            echo $xsdSchema;
+            $output = $this->output->getSymfonyConsoleOutput();
+            $output->write($xsdSchema, $output::OUTPUT_RAW);
         } else {
             file_put_contents($targetFile, $xsdSchema);
         }


### PR DESCRIPTION
Instead of redirecting the stderr output of the processes
to stdout, direct it to stderr as well.

Also use console output write instead of echo in the two 
remaining places.

Fixes #194